### PR TITLE
chore: pin inversify

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "theia-extensions/*"
   ],
   "resolutions": {
+    "inversify": "6.0.3",
     "@types/puppeteer": "^5.4.0",
     "@yarnpkg/parsers": "3.0.0-rc.44",
     "**/multer": "1.4.4-lts.1",

--- a/theia-extensions/product/package.json
+++ b/theia-extensions/product/package.json
@@ -7,8 +7,7 @@
     "@theia/core": "1.55.0",
     "@theia/getting-started": "1.55.0",
     "@theia/vsx-registry": "1.55.0",
-    "@theia/workspace": "1.55.0",
-    "inversify": "6.0.3"
+    "@theia/workspace": "1.55.0"
   },
   "devDependencies": {
     "rimraf": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,24 +967,6 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inversifyjs/common@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.3.2.tgz#883e5972b00e0065e21d300d6e959b188c42fc93"
-  integrity sha512-jIn8Kq8ZfQ/e6FrrKABS3Yju09PQ2L8tLSv+uoJPnBHhj2VHQYOB9qyvJvtCGIrvWC+mAvZ/5RmczXWyEioBjA==
-
-"@inversifyjs/core@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-1.3.3.tgz#e2da8192a9de39e4c6b3cea80b540e702b99cc55"
-  integrity sha512-kDj+ehYA8Q437eZO3gDVDfA/ZhEjRbgORH7kB/7G8JJ0Ij2As2Z3iwLLA9Px1AAOrfocK8JxvH6XAmKE0rALTA==
-  dependencies:
-    "@inversifyjs/common" "1.3.2"
-    "@inversifyjs/reflect-metadata-utils" "0.2.2"
-
-"@inversifyjs/reflect-metadata-utils@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.2.tgz#18eedd4f3a4083928772779668308c95a554cc12"
-  integrity sha512-LaiMbwe4XBzn3GJdYditg0TTSiDMDTY0WuwdQP2BmoGd1e2XSTCIpcjVNqbNLd2dhBLgAEcr7Ep17QLV+DVBAA==
-
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -8367,18 +8349,10 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-inversify@6.0.3:
+inversify@6.0.3, inversify@^6.0.1:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.0.3.tgz#b09e44dad0aaf79bdf92fe788f37507274da21b7"
   integrity sha512-s/svzcRQ/scaGUUyaVtFSL1dvOaRgyvE7VvpGcJwXmFz7CCzfSfxC/Uyl7iSHDEmBabJ2gbDES72DaygtMmwvg==
-
-inversify@^6.0.1:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.1.2.tgz#84fbb96a3162d78b364b4dc259a3086e10232b82"
-  integrity sha512-/qAU7nVM1UmL77RfR6NTd1ye7NITUjegOjz06m3tgcZz0YIaGCsrWfQpFb3HmXMV6IKGjD/e1IeYnq3z/AoQ1w==
-  dependencies:
-    "@inversifyjs/common" "1.3.2"
-    "@inversifyjs/core" "1.3.3"
 
 ip-address@^9.0.5:
   version "9.0.5"


### PR DESCRIPTION
The latest versions of Inversify (>=6.1) are incompatible with the current state of Theia. For now pin the version of Inversify to 6.0.3.

Also removes the redundant dependency in 'theia-ide-product-ext'.

